### PR TITLE
Add JDT Compiler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,11 @@
             </dependency>
             <dependency>
                 <groupId>net.sf.jasperreports</groupId>
+                <artifactId>jasperreports-jdt</artifactId>
+                <version>${version.jasperreports}</version>
+            </dependency>
+            <dependency>
+                <groupId>net.sf.jasperreports</groupId>
                 <artifactId>jasperreports-jaxen</artifactId>
                 <version>${version.jasperreports}</version>
             </dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -57,6 +57,16 @@
         </dependency>
         <dependency>
             <groupId>net.sf.jasperreports</groupId>
+            <artifactId>jasperreports-jdt</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>commons-logging</groupId>
+                    <artifactId>commons-logging</artifactId>
+                </exclusion>
+            </exclusions>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.jasperreports</groupId>
             <artifactId>jasperreports-jaxen</artifactId>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Realized when running the REST services we were getting this error:

```
 [ERROR] Could not compile customerReport.jrxml because Errors were encountered when compiling report expressions class file:
```

This was because we were missing the JDT dependency to allow compiling on the fly.

https://github.com/TIBCOSoftware/jasperreports/issues/460
