### PR TITLE
Replace Jaxen with Xalan

### DIFF
--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -23,7 +23,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jaxb-deployment</artifactId>
+            <artifactId>quarkus-jaxp-deployment</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.poi</groupId>

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/JasperReportsProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/JasperReportsProcessor.java
@@ -102,6 +102,7 @@ class JasperReportsProcessor {
     void registerResourceBuildItems(BuildProducer<NativeImageResourceBuildItem> nativeImageResourceProducer,
             BuildProducer<NativeImageResourceBundleBuildItem> resourceBundleBuildItem) {
         nativeImageResourceProducer.produce(new NativeImageResourceBuildItem(
+                "jasperreports.properties",
                 EXTENSIONS_FILE,
                 "default.jasperreports.properties",
                 "jasperreports_messages.properties",

--- a/pom.xml
+++ b/pom.xml
@@ -71,7 +71,7 @@
             </dependency>
             <dependency>
                 <groupId>net.sf.jasperreports</groupId>
-                <artifactId>jasperreports-jaxen</artifactId>
+                <artifactId>jasperreports-xalan</artifactId>
                 <version>${version.jasperreports}</version>
             </dependency>
             <dependency>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -25,7 +25,7 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
-            <artifactId>quarkus-jaxb</artifactId>
+            <artifactId>quarkus-jaxp</artifactId>
         </dependency>
         <dependency>
             <groupId>io.quarkiverse.poi</groupId>
@@ -67,7 +67,7 @@
         </dependency>
         <dependency>
             <groupId>net.sf.jasperreports</groupId>
-            <artifactId>jasperreports-jaxen</artifactId>
+            <artifactId>jasperreports-xalan</artifactId>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>
@@ -134,11 +134,6 @@
             <groupId>xom</groupId>
             <artifactId>xom</artifactId>
             <version>1.3.9</version>
-        </dependency>
-        <dependency>
-            <groupId>net.sf.saxon</groupId>
-            <artifactId>Saxon-HE</artifactId>
-            <version>12.5</version>
         </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -114,27 +114,6 @@
             <artifactId>icu4j</artifactId>
             <version>75.1</version>
         </dependency>
-        <!-- Jaxen Support -->
-        <dependency>
-            <groupId>org.jdom</groupId>
-            <artifactId>jdom</artifactId>
-            <version>1.1.3</version>
-        </dependency>
-        <dependency>
-            <groupId>org.dom4j</groupId>
-            <artifactId>dom4j</artifactId>
-            <version>2.1.4</version>
-        </dependency>
-        <dependency>
-            <groupId>net.java.dev.msv</groupId>
-            <artifactId>msv-core</artifactId>
-            <version>2022.7</version>
-        </dependency>
-        <dependency>
-            <groupId>xom</groupId>
-            <artifactId>xom</artifactId>
-            <version>1.3.9</version>
-        </dependency>
         <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>

--- a/runtime/pom.xml
+++ b/runtime/pom.xml
@@ -115,6 +115,11 @@
             <version>75.1</version>
         </dependency>
         <dependency>
+            <groupId>net.sf.saxon</groupId>
+            <artifactId>Saxon-HE</artifactId>
+            <version>12.5</version>
+        </dependency>
+        <dependency>
             <groupId>com.github.javaparser</groupId>
             <artifactId>javaparser-core</artifactId>
             <version>3.26.2</version>

--- a/runtime/src/main/resources/jasperreports.properties
+++ b/runtime/src/main/resources/jasperreports.properties
@@ -1,0 +1,2 @@
+net.sf.jasperreports.xpath.executer.factory=net.sf.jasperreports.xalan.util.XalanXPathExecuterFactory
+


### PR DESCRIPTION
This replaces Jaxen with Xalan, which is enabled with quarkus-jaxp
