### PR TITLE
Fix #72: Compiled reports working in native

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/JaxenProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/JaxenProcessor.java
@@ -37,7 +37,7 @@ class JaxenProcessor extends AbstractJandexProcessor {
                 org.jaxen.xom.DocumentNavigator.class.getPackageName()
         ).toList());
         //@formatter:on
-        Log.warnf("Jaxen Runtime: %s", classes);
+        Log.debugf("Jaxen Runtime: %s", classes);
         classes.stream()
                 .map(RuntimeInitializedPackageBuildItem::new)
                 .forEach(runtimeInitializedPackages::produce);
@@ -51,7 +51,7 @@ class JaxenProcessor extends AbstractJandexProcessor {
         classNames.add(net.sf.jasperreports.jaxen.data.JaxenXmlDataSource.class.getName());
         classNames.add(org.jaxen.saxpath.base.XPathReader.class.getName());
 
-        Log.warnf("Jaxen Reflection: %s", classNames);
+        Log.debugf("Jaxen Reflection: %s", classNames);
         // methods and fields
         reflectiveClass.produce(
                 ReflectiveClassBuildItem.builder(classNames.toArray(new String[0])).methods().fields().build());

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/config/ReportConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/config/ReportConfig.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jasperreports.deployment;
+package io.quarkiverse.jasperreports.deployment.config;
 
 import java.nio.file.Path;
 import java.util.Optional;
@@ -11,6 +11,9 @@ import io.smallrye.config.WithDefault;
 @ConfigMapping(prefix = "quarkus.jasperreports")
 @ConfigRoot(phase = ConfigPhase.BUILD_TIME)
 public interface ReportConfig {
+
+    String DEFAULT_SOURCE_PATH = "src/main/jasperreports";
+    String DEFAULT_DEST_PATH = "jasperreports";
 
     /**
      * Configuration options related to automatically building reports.
@@ -28,13 +31,13 @@ public interface ReportConfig {
         /**
          * The path where all source .jrxml files are located.
          */
-        @WithDefault("src/main/jasperreports")
+        @WithDefault(DEFAULT_SOURCE_PATH)
         Optional<Path> source();
 
         /**
          * The path where compiled reports are located.
          */
-        @WithDefault("jasperreports")
+        @WithDefault(DEFAULT_DEST_PATH)
         Optional<Path> destination();
 
     }

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/devui/JasperReportsDevUIProcessor.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/devui/JasperReportsDevUIProcessor.java
@@ -2,7 +2,7 @@ package io.quarkiverse.jasperreports.deployment.devui;
 
 import java.util.List;
 
-import io.quarkiverse.jasperreports.deployment.ReportFileBuildItem;
+import io.quarkiverse.jasperreports.deployment.item.ReportFileBuildItem;
 import io.quarkus.deployment.IsDevelopment;
 import io.quarkus.deployment.annotations.BuildProducer;
 import io.quarkus.deployment.annotations.BuildStep;

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/AbstractReportFileBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/AbstractReportFileBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jasperreports.deployment;
+package io.quarkiverse.jasperreports.deployment.item;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -11,7 +11,7 @@ import io.quarkus.builder.item.MultiBuildItem;
 /**
  * This build item represents a single watched Report file either .jrxml, .jasper, or .jrtx
  */
-public final class ReportFileBuildItem extends MultiBuildItem {
+public abstract class AbstractReportFileBuildItem extends MultiBuildItem {
 
     public final static String EXT_REPORT = "jrxml";
     public final static String EXT_STYLE = "jrtx";
@@ -20,7 +20,7 @@ public final class ReportFileBuildItem extends MultiBuildItem {
 
     private final Path path;
 
-    public ReportFileBuildItem(Path path) {
+    public AbstractReportFileBuildItem(Path path) {
         this.path = path;
     }
 

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/CompiledReportFileBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/CompiledReportFileBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.jasperreports.deployment.item;
+
+import java.nio.file.Path;
+
+/**
+ * This build item represents a single compiled .jasper file.
+ */
+public final class CompiledReportFileBuildItem extends AbstractReportFileBuildItem {
+
+    public CompiledReportFileBuildItem(Path path) {
+        super(path);
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/ReportFileBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/ReportFileBuildItem.java
@@ -1,0 +1,13 @@
+package io.quarkiverse.jasperreports.deployment.item;
+
+import java.nio.file.Path;
+
+/**
+ * This build item represents a single watched Report file either .jrxml, .jasper, or .jrtx
+ */
+public final class ReportFileBuildItem extends AbstractReportFileBuildItem {
+
+    public ReportFileBuildItem(Path path) {
+        super(path);
+    }
+}

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/ReportRootBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/ReportRootBuildItem.java
@@ -1,4 +1,4 @@
-package io.quarkiverse.jasperreports.deployment;
+package io.quarkiverse.jasperreports.deployment.item;
 
 import io.quarkus.builder.item.MultiBuildItem;
 

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
@@ -1,9 +1,7 @@
 package io.quarkiverse.jasperreports.it;
 
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Paths;
-import java.util.List;
+import java.io.InputStream;
+import java.nio.file.Path;
 import java.util.Optional;
 
 import org.eclipse.microprofile.config.inject.ConfigProperty;
@@ -15,59 +13,18 @@ import net.sf.jasperreports.engine.util.JRLoader;
 
 public abstract class AbstractJasperResource {
 
-    @ConfigProperty(name = "quarkus.jasperreports.build.destination", defaultValue = "jasperreports")
-    Optional<String> reportPath;
+    private static final String DEFAULT_PATH = "jasperreports";
+    @ConfigProperty(name = "quarkus.jasperreports.build.destination", defaultValue = DEFAULT_PATH)
+    Optional<String> reportPathConfig;
 
     protected JasperReport compileReport(String jasperFile) throws JRException {
-        JasperReport result;
-        // TODO - Do we need this check anymore?
-        //        if (isRunningInContainer()) {
-        //            result = (JasperReport) JRLoader.loadObject(JRLoader.getLocationInputStream(jasperFile + ".jasper"));
-        //        } else {
-        result = compile(jasperFile);
-        //        }
-        return result;
-    }
-
-    private static boolean isNativeImage() {
-        return System.getProperty("org.graalvm.nativeimage.imagecode") != null;
-    }
-
-    /**
-     * Determines if the application is running inside a container (such as Docker or Kubernetes).
-     * This is done by inspecting the '/proc/1/cgroup' file and checking for the presence of
-     * "docker" or "kubepods". Additionally, it checks specific environment variables to verify
-     * the container environment.
-     *
-     * @return {@code true} if the application is running inside a container; {@code false} otherwise.
-     */
-    protected static boolean isRunningInContainer() {
-        if (isNativeImage())
-            return true;
-
-        try {
-            List<String> lines = Files.readAllLines(Paths.get("/proc/1/cgroup"));
-            for (String line : lines) {
-                if (line.contains("docker") || line.contains("kubepods")) {
-                    return true;
-                }
-            }
-        } catch (IOException e) {
-            // Ignore, likely not in a container if the file doesn't exist
-        }
-
-        // check environment variables
-        return System.getenv("CONTAINER") != null || System.getenv("KUBERNETES_SERVICE_HOST") != null;
-    }
-
-    protected JasperReport compile(String reportName) throws JRException {
-        long start = System.currentTimeMillis();
-
-        JasperReport jasperReport = (JasperReport) JRLoader.loadObject(
-                JRLoader.getLocationInputStream(java.nio.file.Path.of(reportPath.get(), reportName + ".jasper").toString()));
-
-        Log.infof("Loading time : %s", (System.currentTimeMillis() - start));
-
+        final long start = System.currentTimeMillis();
+        final Path reportPath = Path.of(reportPathConfig.orElse(DEFAULT_PATH), jasperFile + ".jasper");
+        final String reportFile = reportPath.toString();
+        final InputStream is = JRLoader.getLocationInputStream(reportFile);
+        final JasperReport jasperReport = (JasperReport) JRLoader.loadObject(is);
+        Log.infof("%S Loading time : %s", jasperFile, (System.currentTimeMillis() - start));
         return jasperReport;
     }
+
 }


### PR DESCRIPTION
Fix #72: Compiled reports working in native

@nderwin your new code let me create a new `CompiledReportBuildItem` and clean up a bunch of my native code for looking through the compiled only files.

let's see if this passes