### PR TITLE
provide a default repository implementation

### DIFF
--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/config/ReportConfig.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/config/ReportConfig.java
@@ -28,7 +28,7 @@ public interface ReportConfig {
         boolean enable();
 
         /**
-         * The path where all source .jrxml files are located.
+         * The path where all source <code>.jrxml</code> and <code>.jrtx</code> files are located.
          */
         @WithDefault(DEFAULT_SOURCE_PATH)
         Path source();

--- a/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/AbstractReportFileBuildItem.java
+++ b/deployment/src/main/java/io/quarkiverse/jasperreports/deployment/item/AbstractReportFileBuildItem.java
@@ -1,5 +1,10 @@
 package io.quarkiverse.jasperreports.deployment.item;
 
+import static io.quarkiverse.jasperreports.Constants.EXT_COMPILED;
+import static io.quarkiverse.jasperreports.Constants.EXT_DATA_ADAPTER;
+import static io.quarkiverse.jasperreports.Constants.EXT_REPORT;
+import static io.quarkiverse.jasperreports.Constants.EXT_STYLE;
+
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Locale;
@@ -13,10 +18,6 @@ import io.quarkus.builder.item.MultiBuildItem;
  */
 public abstract class AbstractReportFileBuildItem extends MultiBuildItem {
 
-    public final static String EXT_REPORT = "jrxml";
-    public final static String EXT_STYLE = "jrtx";
-    public final static String EXT_DATA_ADAPTER = "jrdax";
-    public final static String EXT_COMPILED = "jasper";
     public final static List<String> EXTENSIONS = List.of("." + EXT_REPORT, "." + EXT_COMPILED, "." + EXT_STYLE,
             "." + EXT_DATA_ADAPTER);
 

--- a/docs/modules/ROOT/pages/includes/quarkus-jasperreports.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jasperreports.adoc
@@ -29,7 +29,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-jasperreports_quarkus-jasperrep
 
 [.description]
 --
-The path where all source .jrxml files are located.
+The path where all source `.jrxml` and `.jrtx` files are located.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/includes/quarkus-jasperreports_quarkus.jasperreports.adoc
+++ b/docs/modules/ROOT/pages/includes/quarkus-jasperreports_quarkus.jasperreports.adoc
@@ -29,7 +29,7 @@ a|icon:lock[title=Fixed at build time] [[quarkus-jasperreports_quarkus-jasperrep
 
 [.description]
 --
-The path where all source .jrxml files are located.
+The path where all source `.jrxml` and `.jrtx` files are located.
 
 
 ifdef::add-copy-button-to-env-var[]

--- a/docs/modules/ROOT/pages/index.adoc
+++ b/docs/modules/ROOT/pages/index.adoc
@@ -93,6 +93,22 @@ CMD ["./application", "-Dquarkus.http.host=0.0.0.0"]
 
 CAUTION: Make sure `.dockerignore` does not exclude `.so` files!
 
+== Read-Only Streaming Service
+
+A JasperReports repository can handle loading all of the resources a report needs, including any referenced subreports.  Simply inject the repository,
+then use it with the fill manager to produce the report.
+
+[source,java]
+----
+    @Inject
+    ReadOnlyStreamingService repo;
+
+    public JasperPrint fill() throws JRException {
+        Map<String, Object> params = new HashMap<>();
+        return JasperFillManager.getInstance(repo.getContext()).fillFromRepo("MyReport.jasper", params);
+    }
+----
+
 [[extension-configuration-reference]]
 == Extension Configuration Reference
 

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
@@ -1,36 +1,14 @@
 package io.quarkiverse.jasperreports.it;
 
 import java.io.ByteArrayOutputStream;
-import java.io.InputStream;
-import java.nio.file.Path;
-import java.util.Optional;
 
-import org.eclipse.microprofile.config.inject.ConfigProperty;
-
-import io.quarkus.logging.Log;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperPrint;
-import net.sf.jasperreports.engine.JasperReport;
 import net.sf.jasperreports.engine.export.JRCsvExporter;
-import net.sf.jasperreports.engine.util.JRLoader;
 import net.sf.jasperreports.export.SimpleExporterInput;
 import net.sf.jasperreports.export.SimpleWriterExporterOutput;
 
 public abstract class AbstractJasperResource {
-
-    private static final String DEFAULT_PATH = "jasperreports";
-    @ConfigProperty(name = "quarkus.jasperreports.build.destination", defaultValue = DEFAULT_PATH)
-    Optional<String> reportPathConfig;
-
-    protected JasperReport compileReport(String jasperFile) throws JRException {
-        final long start = System.currentTimeMillis();
-        final Path reportPath = Path.of(reportPathConfig.orElse(DEFAULT_PATH), jasperFile + ".jasper");
-        final String reportFile = reportPath.toString();
-        final InputStream is = JRLoader.getLocationInputStream(reportFile);
-        final JasperReport jasperReport = (JasperReport) JRLoader.loadObject(is);
-        Log.infof("%S Loading time : %s", jasperFile, (System.currentTimeMillis() - start));
-        return jasperReport;
-    }
 
     protected ByteArrayOutputStream exportCsv(JasperPrint jasperPrint) throws JRException {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();

--- a/runtime/src/main/java/io/quarkiverse/jasperreports/Constants.java
+++ b/runtime/src/main/java/io/quarkiverse/jasperreports/Constants.java
@@ -1,0 +1,17 @@
+package io.quarkiverse.jasperreports;
+
+public interface Constants {
+
+    static final String EXT_REPORT = "jrxml";
+
+    static final String EXT_STYLE = "jrtx";
+
+    static final String EXT_DATA_ADAPTER = "jrdax";
+
+    static final String EXT_COMPILED = "jasper";
+
+    static final String DEFAULT_SOURCE_PATH = "src/main/jasperreports";
+
+    static final String DEFAULT_DEST_PATH = "jasperreports";
+
+}

--- a/runtime/src/main/java/io/quarkiverse/jasperreports/repository/ReadOnlyStreamingService.java
+++ b/runtime/src/main/java/io/quarkiverse/jasperreports/repository/ReadOnlyStreamingService.java
@@ -1,0 +1,115 @@
+package io.quarkiverse.jasperreports.repository;
+
+import static io.quarkiverse.jasperreports.Constants.EXT_COMPILED;
+import static io.quarkiverse.jasperreports.Constants.EXT_DATA_ADAPTER;
+import static io.quarkiverse.jasperreports.Constants.EXT_STYLE;
+
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Path;
+import java.util.Collections;
+import java.util.Optional;
+
+import jakarta.annotation.PostConstruct;
+import jakarta.enterprise.context.Dependent;
+
+import org.eclipse.microprofile.config.inject.ConfigProperty;
+import org.jboss.logging.Logger;
+
+import io.quarkiverse.jasperreports.Constants;
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JasperReportsContext;
+import net.sf.jasperreports.engine.SimpleJasperReportsContext;
+import net.sf.jasperreports.engine.util.JRLoader;
+import net.sf.jasperreports.repo.FileRepositoryPersistenceServiceFactory;
+import net.sf.jasperreports.repo.FileRepositoryService;
+import net.sf.jasperreports.repo.PersistenceService;
+import net.sf.jasperreports.repo.PersistenceServiceFactory;
+import net.sf.jasperreports.repo.PersistenceUtil;
+import net.sf.jasperreports.repo.RepositoryService;
+import net.sf.jasperreports.repo.Resource;
+import net.sf.jasperreports.repo.SimpleRepositoryContext;
+import net.sf.jasperreports.repo.StreamRepositoryService;
+
+@Dependent
+public class ReadOnlyStreamingService implements StreamRepositoryService {
+
+    private static final Logger LOG = Logger.getLogger(ReadOnlyStreamingService.class);
+
+    private final JasperReportsContext context = new SimpleJasperReportsContext();
+
+    // TODO - why is it not picking up the default value from ReportConfig???
+    @ConfigProperty(name = "quarkus.jasperreports.build.destination", defaultValue = Constants.DEFAULT_DEST_PATH)
+    Optional<Path> reportPathConfig;
+
+    @PostConstruct
+    public void onInit() {
+        ((SimpleJasperReportsContext) context).setExtensions(RepositoryService.class, Collections.singletonList(this));
+        ((SimpleJasperReportsContext) context).setExtensions(PersistenceServiceFactory.class,
+                Collections.singletonList(FileRepositoryPersistenceServiceFactory.getInstance()));
+    }
+
+    public JasperReportsContext getContext() {
+        return context;
+    }
+
+    @Override
+    public InputStream getInputStream(String uri) {
+        InputStream is = null;
+
+        if (uri.endsWith(EXT_COMPILED) || uri.endsWith(EXT_STYLE)) {
+            final Path reportPath = Path.of(reportPathConfig.get().toString(), uri);
+            final String reportFile = reportPath.toString();
+
+            try {
+                LOG.debugf("Loading %s file %s", (uri.endsWith(EXT_COMPILED) ? "report" : "style"), reportFile);
+
+                return JRLoader.getLocationInputStream(reportFile);
+            } catch (JRException ex) {
+                LOG.warnf("Failed to load %s - %s", (uri.endsWith(EXT_COMPILED) ? "report" : "style"), ex.getMessage());
+                LOG.debug(ex);
+            }
+        } else if (uri.endsWith(EXT_DATA_ADAPTER)) {
+            try {
+                LOG.debugf("Loading data adapter file %s", uri);
+
+                return JRLoader.getLocationInputStream(uri);
+            } catch (JRException ex) {
+                LOG.warnf("Failed to load data adapter - %s", ex.getMessage());
+                LOG.debug(ex);
+            }
+        }
+
+        return is;
+    }
+
+    @Override
+    public OutputStream getOutputStream(String uri) {
+        throw new IllegalStateException("This repository is read only");
+    }
+
+    @Override
+    public Resource getResource(String uri) {
+        throw new IllegalStateException("Can only return an InputStream");
+    }
+
+    @Override
+    public void saveResource(String uri, Resource resource) {
+        throw new IllegalStateException("This repository is read only");
+    }
+
+    @Override
+    @SuppressWarnings("unchecked")
+    public <T extends Resource> T getResource(String uri, Class<T> resourceType) {
+        final PersistenceService persistenceService = PersistenceUtil.getInstance(context).getService(
+                FileRepositoryService.class,
+                resourceType);
+
+        if (null != persistenceService) {
+            return (T) persistenceService.load(SimpleRepositoryContext.of(context), uri, this);
+        }
+
+        return null;
+    }
+
+}


### PR DESCRIPTION
* centralized some constants into a runtime class that can be used in multiple places
* added a default read-only repository that can load a report file and any of it's subreports
* added a build step to produce the default repository bean
* updated the tests (except the JSON data source tests) to use the repository instead of doing the loading themselves
* added a blurb in the docs about using the repository

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>