### PR TITLE
add tests for using style templates

### DIFF
--- a/integration-tests/src/main/jasperreports/StylesReport.jrxml
+++ b/integration-tests/src/main/jasperreports/StylesReport.jrxml
@@ -1,0 +1,44 @@
+<jasperReport name="StylesReport" language="java" pageWidth="595" pageHeight="842" whenNoDataType="AllSectionsNoDetail" columnWidth="555" leftMargin="20" rightMargin="20" topMargin="30" bottomMargin="30" uuid="53f914b8-f951-4433-971d-6b1819430c56">
+	<template><![CDATA["styles.jrtx"]]></template>
+	<style name="Right Aligned" style="Regular" hTextAlign="Right" hImageAlign="Right"/>
+	<style name="More Emphasis" style="Emphasis" mode="Opaque" backcolor="#FFC800" fontSize="14.0"/>
+	<style name="Serif Note" style="Serif" mode="Opaque" forecolor="#FFC800" backcolor="#404040" fontSize="10.0"/>
+	<title height="782">
+		<element kind="textField" uuid="75dc6b08-96e0-45b9-a771-9e884cc4aafb" x="0" y="0" width="555" height="25" textAdjust="StretchHeight">
+			<expression><![CDATA["Regular (default): font size = 12, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="d74f4c94-b8ae-4627-a7fc-6651b2eaecdf" x="0" y="30" width="555" height="25" textAdjust="StretchHeight" underline="true">
+			<expression><![CDATA["Regular (modified): font size = 12, underlined, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="e35e4360-5387-4e05-a931-097091258215" positionType="Float" x="0" y="60" width="555" height="25" textAdjust="StretchHeight" style="Right Aligned">
+			<expression><![CDATA["Right Aligned: font size = 12, right aligned, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="ba12716b-8e1e-4379-8ec1-a3ff34d99e20" positionType="Float" x="0" y="90" width="555" height="25" textAdjust="StretchHeight" style="Emphasis">
+			<expression><![CDATA["Emphasis: font size = 10, italic, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="f370465b-2cfd-41c5-b48a-e4c3b0afe86f" positionType="Float" x="0" y="120" width="555" height="25" textAdjust="StretchHeight" style="Special Emphasis">
+			<expression><![CDATA["Special Emphasis: font size = 12, red, italic, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="c864bf3d-2357-46c1-a22d-611159c6be51" positionType="Float" x="0" y="150" width="555" height="25" textAdjust="StretchHeight" style="More Emphasis">
+			<expression><![CDATA["More Emphasis: font size = 14, black on orange, italic, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="34e8a2ef-6903-425d-809e-1d395fc9b683" positionType="Float" x="0" y="180" width="555" height="25" textAdjust="StretchHeight" style="Strong">
+			<expression><![CDATA["Strong: font size = 14, underlined, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="3f80426c-2b53-49c4-9556-c2ae6cd8d564" positionType="Float" x="0" y="210" width="555" height="25" textAdjust="StretchHeight" style="Very Strong">
+			<expression><![CDATA["Very Strong: font size = 12, black on light gray, bold, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="7cbc0ad3-1d9c-4f0e-a4c7-2e1055be690a" positionType="Float" x="0" y="240" width="555" height="25" backcolor="#FFC800" textAdjust="StretchHeight" style="Very Strong">
+			<expression><![CDATA["Very Strong (modified): font size = 12, black on orange, bold, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="af97e5bb-2d6a-4fae-bc17-bad21101a3a1" positionType="Float" x="0" y="270" width="555" height="25" textAdjust="StretchHeight" style="Serif">
+			<expression><![CDATA["Serif: font face = DejaVu Serif, font size = 12, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="ed44229f-c431-447c-8f46-0113ecc9affa" positionType="Float" x="0" y="300" width="555" height="25" markup="styled" textAdjust="StretchHeight" style="Serif">
+			<expression><![CDATA["Serif (styled): font face = DejaVu Serif, font size = 12, <style forecolor=\"red\">partially red</style>, centered, border"]]></expression>
+		</element>
+		<element kind="textField" uuid="6dc9246d-95be-4d9c-abb8-9dbdcc6dcea8" positionType="Float" x="0" y="330" width="555" height="25" textAdjust="StretchHeight" style="Serif Note">
+			<expression><![CDATA["Serif Note: font face = DejaVu Serif, font size = 10, orange on dark gray, centered, border"]]></expression>
+		</element>
+	</title>
+</jasperReport>

--- a/integration-tests/src/main/jasperreports/base_styles.jrtx
+++ b/integration-tests/src/main/jasperreports/base_styles.jrtx
@@ -1,0 +1,10 @@
+<jasperTemplate>
+  <style name="Base" hTextAlign="Center" vTextAlign="Middle" hImageAlign="Center" vImageAlign="Middle" fontSize="10.0" pdfFontName="Helvetica" pdfEncoding="Cp1252" default="true" pdfEmbedded="false">
+    <box padding="4">
+      <pen lineWidth="0.5"/>
+    </box>
+  </style>
+  <style name="Emphasis" pdfFontName="Helvetica-Oblique" italic="true" style="Base"/>
+  <style name="Strong" fontSize="12.0" pdfFontName="Helvetica-Bold" bold="true" style="Base"/>
+  <style name="Very Strong" mode="Opaque" backcolor="#C0C0C0" style="Strong"/>
+</jasperTemplate>

--- a/integration-tests/src/main/jasperreports/styles.jrtx
+++ b/integration-tests/src/main/jasperreports/styles.jrtx
@@ -1,0 +1,8 @@
+<jasperTemplate>
+  <template>base_styles.jrtx</template>
+  <style name="Regular" fontSize="12.0" default="true" style="Base"/>
+  <style name="Special Emphasis" forecolor="#FF0000" fontSize="12.0" style="Emphasis"/>
+  <style name="Strong" fontSize="14.0" underline="true" style="Base"/>
+  <style name="Serif" fontName="DejaVu Serif" fontSize="12.0" style="Base"/>
+  <style name="Serif Note" underline="true" style="Serif"/>
+</jasperTemplate>

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/AbstractJasperResource.java
@@ -2,11 +2,21 @@ package io.quarkiverse.jasperreports.it;
 
 import java.io.ByteArrayOutputStream;
 
+import net.sf.jasperreports.engine.DefaultJasperReportsContext;
 import net.sf.jasperreports.engine.JRException;
 import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.export.HtmlExporter;
 import net.sf.jasperreports.engine.export.JRCsvExporter;
+import net.sf.jasperreports.engine.export.JRRtfExporter;
+import net.sf.jasperreports.engine.export.JRXmlExporter;
+import net.sf.jasperreports.engine.export.oasis.JROdsExporter;
+import net.sf.jasperreports.engine.export.oasis.JROdtExporter;
 import net.sf.jasperreports.export.SimpleExporterInput;
+import net.sf.jasperreports.export.SimpleHtmlExporterOutput;
+import net.sf.jasperreports.export.SimpleOdsReportConfiguration;
+import net.sf.jasperreports.export.SimpleOutputStreamExporterOutput;
 import net.sf.jasperreports.export.SimpleWriterExporterOutput;
+import net.sf.jasperreports.export.SimpleXmlExporterOutput;
 
 public abstract class AbstractJasperResource {
 
@@ -15,6 +25,68 @@ public abstract class AbstractJasperResource {
         JRCsvExporter exporter = new JRCsvExporter();
         exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
         exporter.setExporterOutput(new SimpleWriterExporterOutput(outputStream));
+
+        exporter.exportReport();
+        return outputStream;
+    }
+
+    protected ByteArrayOutputStream exportXml(JasperPrint jasperPrint, boolean embeddedImages) throws JRException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JRXmlExporter exporter = new JRXmlExporter(DefaultJasperReportsContext.getInstance());
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+
+        SimpleXmlExporterOutput xmlOutput = new SimpleXmlExporterOutput(outputStream);
+        xmlOutput.setEmbeddingImages(embeddedImages);
+        exporter.setExporterOutput(xmlOutput);
+
+        exporter.exportReport();
+        return outputStream;
+    }
+
+    protected ByteArrayOutputStream exportHtml(JasperPrint jasperPrint) throws JRException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        HtmlExporter exporter = new HtmlExporter(DefaultJasperReportsContext.getInstance());
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+        exporter.setExporterOutput(new SimpleHtmlExporterOutput(outputStream));
+
+        exporter.exportReport();
+        return outputStream;
+    }
+
+    protected ByteArrayOutputStream exportRtf(JasperPrint jasperPrint) throws JRException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JRRtfExporter exporter = new JRRtfExporter();
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+        exporter.setExporterOutput(new SimpleWriterExporterOutput(outputStream));
+
+        exporter.exportReport();
+        return outputStream;
+    }
+
+    protected ByteArrayOutputStream exportOdt(JasperPrint jasperPrint) throws JRException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JROdtExporter exporter = new JROdtExporter();
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+        exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
+
+        exporter.exportReport();
+        return outputStream;
+    }
+
+    protected ByteArrayOutputStream exportOds(JasperPrint jasperPrint) throws JRException {
+        ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+        JROdsExporter exporter = new JROdsExporter();
+
+        exporter.setExporterInput(new SimpleExporterInput(jasperPrint));
+        exporter.setExporterOutput(new SimpleOutputStreamExporterOutput(outputStream));
+
+        SimpleOdsReportConfiguration configuration = new SimpleOdsReportConfiguration();
+        configuration.setOnePagePerSheet(true);
+        exporter.setConfiguration(configuration);
 
         exporter.exportReport();
         return outputStream;

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/ExtendedMediaType.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/ExtendedMediaType.java
@@ -1,0 +1,44 @@
+package io.quarkiverse.jasperreports.it;
+
+import jakarta.ws.rs.core.MediaType;
+
+public class ExtendedMediaType extends MediaType {
+
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_DOCX} media type.
+     */
+    public static final String APPLICATION_DOCX = "application/vnd.openxmlformats-officedocument.wordprocessingml.document";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_OPENDOCUMENT_SPREADSHEET} media type.
+     */
+    public static final String APPLICATION_OPENDOCUMENT_SPREADSHEET = "application/vnd.oasis.opendocument.spreadsheet";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_OPENDOCUMENT_TEXT} media type.
+     */
+    public static final String APPLICATION_OPENDOCUMENT_TEXT = "application/vnd.oasis.opendocument.text";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_PDF} media type.
+     */
+    public static final String APPLICATION_PDF = "application/pdf";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_PPTX} media type.
+     */
+    public static final String APPLICATION_PPTX = "application/vnd.openxmlformats-officedocument.presentationml.presentation";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_RTF} media type.
+     */
+    public static final String APPLICATION_RTF = "application/rtf";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_XLS} media type.
+     */
+    public static final String APPLICATION_XLS = "application/vnd.ms-excel";
+    /**
+     * A {@code String} constant representing {@value #APPLICATION_XLSX} media type.
+     */
+    public static final String APPLICATION_XLSX = "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet";
+    /**
+     * A {@code String} constant representing {@value #TEXT_CSV} media type.
+     */
+    public static final String TEXT_CSV = "text/csv";
+
+}

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsCsvResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsCsvResource.java
@@ -26,6 +26,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -77,8 +78,8 @@ public class JasperReportsCsvResource extends AbstractJasperResource {
 
             Log.infof("CSV creation time : %s", (System.currentTimeMillis() - start));
             final Response.ResponseBuilder response = Response.ok(outputStream.toByteArray());
-            response.header("Content-Disposition", "attachment;filename=csvdatasource.csv");
-            response.header("Content-Type", "text/csv");
+            response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=csvdatasource.csv");
+            response.header(HttpHeaders.CONTENT_TYPE, ExtendedMediaType.TEXT_CSV);
             return response.build();
         } catch (final JRException ex) {
             Log.error("Unexpected DB Error", ex);

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsJsonResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsJsonResource.java
@@ -26,6 +26,7 @@ import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.Produces;
 import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -84,8 +85,8 @@ public class JasperReportsJsonResource extends AbstractJasperResource {
 
             Log.infof("CSV creation time : %s", (System.currentTimeMillis() - start));
             final Response.ResponseBuilder response = Response.ok(outputStream.toByteArray());
-            response.header("Content-Disposition", "attachment;filename=" + reportFile + ".csv");
-            response.header("Content-Type", "text/csv");
+            response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=" + reportFile + ".csv");
+            response.header(HttpHeaders.CONTENT_TYPE, ExtendedMediaType.TEXT_CSV);
             return response.build();
         } catch (final JRException ex) {
             Log.error("Unexpected DB Error", ex);

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsPdfEncryptResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsPdfEncryptResource.java
@@ -22,6 +22,7 @@ import jakarta.enterprise.context.ApplicationScoped;
 import jakarta.ws.rs.GET;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.ServerErrorException;
+import jakarta.ws.rs.core.HttpHeaders;
 import jakarta.ws.rs.core.MediaType;
 import jakarta.ws.rs.core.Response;
 
@@ -80,8 +81,8 @@ public class JasperReportsPdfEncryptResource extends AbstractJasperResource {
             Log.infof("PDF creation time : %s", (System.currentTimeMillis() - start));
 
             final Response.ResponseBuilder response = Response.ok(outputStream.toByteArray());
-            response.header("Content-Disposition", "attachment;filename=encrypted.pdf");
-            response.header("Content-Type", "application/pdf");
+            response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=encrypted.pdf");
+            response.header(HttpHeaders.CONTENT_TYPE, "application/pdf");
             return response.build();
         } catch (final JRException ex) {
             Log.error("Unexpected DB Error", ex);

--- a/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsStyleResource.java
+++ b/integration-tests/src/main/java/io/quarkiverse/jasperreports/it/JasperReportsStyleResource.java
@@ -1,0 +1,143 @@
+/*
+* Licensed to the Apache Software Foundation (ASF) under one or more
+* contributor license agreements.  See the NOTICE file distributed with
+* this work for additional information regarding copyright ownership.
+* The ASF licenses this file to You under the Apache License, Version 2.0
+* (the "License"); you may not use this file except in compliance with
+* the License.  You may obtain a copy of the License at
+*
+*      http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+package io.quarkiverse.jasperreports.it;
+
+import static io.quarkiverse.jasperreports.it.ExtendedMediaType.APPLICATION_OPENDOCUMENT_TEXT;
+import static io.quarkiverse.jasperreports.it.ExtendedMediaType.APPLICATION_RTF;
+import static io.quarkiverse.jasperreports.it.ExtendedMediaType.TEXT_CSV;
+import static jakarta.ws.rs.core.MediaType.APPLICATION_XML;
+import static jakarta.ws.rs.core.MediaType.TEXT_HTML;
+import static jakarta.ws.rs.core.MediaType.WILDCARD;
+
+import java.io.ByteArrayOutputStream;
+import java.util.HashMap;
+import java.util.Locale;
+import java.util.Map;
+
+import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.DefaultValue;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.QueryParam;
+import jakarta.ws.rs.core.Context;
+import jakarta.ws.rs.core.HttpHeaders;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+
+import org.eclipse.microprofile.openapi.annotations.enums.SchemaType;
+import org.eclipse.microprofile.openapi.annotations.media.Content;
+import org.eclipse.microprofile.openapi.annotations.media.Schema;
+import org.eclipse.microprofile.openapi.annotations.responses.APIResponse;
+import org.w3c.dom.Document;
+
+import io.quarkiverse.jasperreports.repository.ReadOnlyStreamingService;
+import io.quarkus.logging.Log;
+import net.sf.jasperreports.engine.JRException;
+import net.sf.jasperreports.engine.JRParameter;
+import net.sf.jasperreports.engine.JasperFillManager;
+import net.sf.jasperreports.engine.JasperPrint;
+import net.sf.jasperreports.engine.ReportContext;
+import net.sf.jasperreports.engine.SimpleReportContext;
+import net.sf.jasperreports.engine.query.JRXPathQueryExecuterFactory;
+import net.sf.jasperreports.engine.util.JRLoader;
+import net.sf.jasperreports.engine.util.JRXmlUtils;
+
+@Path("jasper/style")
+@ApplicationScoped
+@Produces({
+        TEXT_CSV,
+        APPLICATION_XML,
+        TEXT_HTML,
+        APPLICATION_RTF,
+        APPLICATION_OPENDOCUMENT_TEXT
+})
+public class JasperReportsStyleResource extends AbstractJasperResource {
+
+    private static final String TEST_REPORT_NAME = "StylesReport.jasper";
+
+    @Inject
+    ReadOnlyStreamingService repo;
+
+    @APIResponse(responseCode = "200", description = "Fetch the report output based on the requested content type", content = {
+            @Content(mediaType = TEXT_CSV),
+            @Content(mediaType = APPLICATION_XML),
+            @Content(mediaType = TEXT_HTML),
+            @Content(mediaType = APPLICATION_RTF, schema = @Schema(type = SchemaType.STRING, format = "binary")),
+            @Content(mediaType = APPLICATION_OPENDOCUMENT_TEXT, schema = @Schema(type = SchemaType.STRING, format = "binary"))
+    })
+    @GET
+    public Response get(@Context HttpHeaders headers,
+            @DefaultValue("false") @QueryParam("embedded") boolean embedded) throws JRException {
+        final ReportContext reportContext = new SimpleReportContext();
+
+        final Map<String, Object> params = new HashMap<>();
+        Document document = JRXmlUtils.parse(JRLoader.getLocationInputStream("data/northwind.xml"));
+        params.put(JRXPathQueryExecuterFactory.PARAMETER_XML_DATA_DOCUMENT, document);
+        params.put(JRXPathQueryExecuterFactory.XML_DATE_PATTERN, "yyyy-MM-dd");
+        params.put(JRXPathQueryExecuterFactory.XML_NUMBER_PATTERN, "#,##0.##");
+        params.put(JRXPathQueryExecuterFactory.XML_LOCALE, Locale.ENGLISH);
+        params.put(JRParameter.REPORT_LOCALE, Locale.US);
+        params.put(JRParameter.REPORT_CONTEXT, reportContext);
+
+        final long start = System.currentTimeMillis();
+        final JasperPrint jasperPrint = JasperFillManager.getInstance(repo.getContext()).fillFromRepo(TEST_REPORT_NAME, params);
+
+        final Response.ResponseBuilder response = Response.ok();
+
+        switch (headers.getAcceptableMediaTypes().iterator().next().toString()) {
+            case WILDCARD, TEXT_CSV -> {
+                ByteArrayOutputStream outputStream = exportCsv(jasperPrint);
+                Log.infof("CSV creation time : %s", (System.currentTimeMillis() - start));
+                response.entity(outputStream.toByteArray());
+                response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=jasper.csv");
+                response.type(TEXT_CSV);
+            }
+            case APPLICATION_XML -> {
+                ByteArrayOutputStream outputStream = exportXml(jasperPrint, embedded);
+                Log.infof("XML creation time : %s", (System.currentTimeMillis() - start));
+                response.entity(outputStream.toByteArray());
+                response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=jasper.xml");
+                response.type(MediaType.APPLICATION_XML);
+            }
+            case TEXT_HTML -> {
+                ByteArrayOutputStream outputStream = exportHtml(jasperPrint);
+                Log.infof("HTML creation time : %s", (System.currentTimeMillis() - start));
+                response.entity(outputStream.toByteArray());
+                response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=jasper.html");
+                response.type(MediaType.TEXT_HTML);
+            }
+            case APPLICATION_RTF -> {
+                ByteArrayOutputStream outputStream = exportRtf(jasperPrint);
+                Log.infof("RTF creation time : %s", (System.currentTimeMillis() - start));
+                response.entity(outputStream.toByteArray());
+                response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=jasper.rtf");
+                response.type(ExtendedMediaType.APPLICATION_RTF);
+            }
+            case APPLICATION_OPENDOCUMENT_TEXT -> {
+                ByteArrayOutputStream outputStream = exportOdt(jasperPrint);
+                Log.infof("ODT creation time : %s", (System.currentTimeMillis() - start));
+                response.entity(outputStream.toByteArray());
+                response.header(HttpHeaders.CONTENT_DISPOSITION, "attachment;filename=jasper.odt");
+                response.type(ExtendedMediaType.APPLICATION_OPENDOCUMENT_TEXT);
+            }
+        }
+
+        return response.build();
+    }
+}


### PR DESCRIPTION
* Fixes #116
* added an example report that uses styles
* fixed the processor to not attempt to compile the styles, but instead just copy them to the output directory
* added some constants for media types
* use constants for header names were possible
* added a new REST service to wrap all the different output formats for the styled report
* centralized the export methods so they could be reused between the REST endpoints

Signed-off-by:Nathan Erwin <nathan.d.erwin@gmail.com>